### PR TITLE
Update model spacing

### DIFF
--- a/composition-beta
+++ b/composition-beta
@@ -1,0 +1,674 @@
+{
+  "version": "0.1.1",
+  "timestamp": 1564441586896,
+  "model": {
+    "id": 2,
+    "class": "heronarts.lx.structure.LXStructure",
+    "modulationColor": -29440,
+    "internal": {},
+    "parameters": {
+      "label": "LX",
+      "syncModelFile": false
+    },
+    "children": {}
+  },
+  "engine": {
+    "id": 1,
+    "class": "heronarts.lx.LXEngine",
+    "modulationColor": -16769537,
+    "internal": {},
+    "parameters": {
+      "label": "Engine",
+      "scene-1": false,
+      "scene-2": false,
+      "scene-3": false,
+      "scene-4": false,
+      "scene-5": false,
+      "crossfader": 0.5,
+      "crossfaderBlendMode": 0,
+      "speed": 1.0,
+      "focusedChannel": 0,
+      "cueA": false,
+      "cueB": false,
+      "multithreaded": true,
+      "channelMultithreaded": false,
+      "networkMultithreaded": false,
+      "framesPerSecond": 30.0,
+      "mixerViewCondensed": false
+    },
+    "children": {
+      "palette": {
+        "id": 11,
+        "class": "heronarts.lx.color.LXPalette",
+        "modulationColor": -16711842,
+        "internal": {},
+        "parameters": {
+          "label": "LX",
+          "hueMode": 0,
+          "color/brightness": 100.0,
+          "color/saturation": 100.0,
+          "color/hue": 0.0,
+          "period": 120000.0,
+          "range": 10.0
+        },
+        "children": {}
+      },
+      "tempo": {
+        "id": 15,
+        "class": "heronarts.lx.Tempo",
+        "modulationColor": -65343,
+        "internal": {},
+        "parameters": {
+          "label": "Tempo",
+          "clockSource": 0,
+          "period": 500.0,
+          "bpm": 120.0,
+          "tap": false,
+          "nudgeUp": false,
+          "nudgeDown": false,
+          "beatsPerMeasure": 4,
+          "trigger": false,
+          "enabled": false
+        },
+        "children": {}
+      },
+      "modulation": {
+        "id": 17,
+        "class": "heronarts.lx.LXModulationEngine",
+        "modulationColor": -16753409,
+        "internal": {},
+        "parameters": {
+          "label": "Modulation"
+        },
+        "children": {},
+        "modulators": [],
+        "modulations": [],
+        "triggers": []
+      },
+      "master": {
+        "id": 18,
+        "class": "heronarts.lx.LXMasterChannel",
+        "modulationColor": -16711855,
+        "internal": {},
+        "parameters": {
+          "label": "Master",
+          "arm": false,
+          "selected": false
+        },
+        "children": {},
+        "effects": [],
+        "clips": []
+      },
+      "output": {
+        "id": 19,
+        "class": "heronarts.lx.LXEngine$Output",
+        "modulationColor": -65345,
+        "internal": {},
+        "parameters": {
+          "label": "Output",
+          "enabled": false,
+          "fps": 0.0,
+          "gamma": 1.0,
+          "brightness": 1.0
+        },
+        "children": {}
+      },
+      "midi": {
+        "id": 21,
+        "class": "heronarts.lx.midi.LXMidiEngine",
+        "modulationColor": -16711758,
+        "internal": {},
+        "parameters": {
+          "label": "LX",
+          "computerKeyboardEnabled": false
+        },
+        "children": {},
+        "inputs": [],
+        "surfaces": [],
+        "mapping": []
+      },
+      "audio": {
+        "id": 22,
+        "class": "heronarts.lx.audio.LXAudioEngine",
+        "modulationColor": -65367,
+        "internal": {},
+        "parameters": {
+          "label": "Audio",
+          "enabled": false,
+          "mode": 0
+        },
+        "children": {
+          "input": {
+            "id": 23,
+            "class": "heronarts.lx.audio.LXAudioInput",
+            "modulationColor": -10026753,
+            "internal": {},
+            "parameters": {
+              "label": "Input",
+              "device": 0
+            },
+            "children": {}
+          },
+          "output": {
+            "id": 24,
+            "class": "heronarts.lx.audio.LXAudioOutput",
+            "modulationColor": -65524,
+            "internal": {},
+            "parameters": {
+              "label": "Output",
+              "file": "",
+              "trigger": false,
+              "looping": false,
+              "play": false
+            },
+            "children": {}
+          },
+          "meter": {
+            "id": 25,
+            "class": "heronarts.lx.audio.GraphicMeter",
+            "modulationColor": -16711783,
+            "internal": {},
+            "parameters": {
+              "label": "Meter",
+              "running": false,
+              "trigger": false,
+              "gain": 0.0,
+              "range": 48.0,
+              "attack": 10.0,
+              "release": 100.0,
+              "slope": 4.5,
+              "Band-1": 0.0,
+              "Band-2": 0.0,
+              "Band-3": 0.0,
+              "Band-4": 0.0,
+              "Band-5": 0.0,
+              "Band-6": 0.0,
+              "Band-7": 0.0,
+              "Band-8": 0.0,
+              "Band-9": 0.0,
+              "Band-10": 0.0,
+              "Band-11": 0.0,
+              "Band-12": 0.0,
+              "Band-13": 0.0,
+              "Band-14": 0.0,
+              "Band-15": 0.0,
+              "Band-16": 0.0
+            },
+            "children": {}
+          }
+        }
+      },
+      "osc": {
+        "id": 26,
+        "class": "heronarts.lx.osc.LXOscEngine",
+        "modulationColor": -16711709,
+        "internal": {},
+        "parameters": {
+          "label": "OSC",
+          "receiveHost": "0.0.0.0",
+          "receivePort": 3030,
+          "receiveActive": true,
+          "transmitHost": "localhost",
+          "transmitPort": 3131,
+          "transmitActive": false
+        },
+        "children": {}
+      }
+    },
+    "channels": [
+      {
+        "id": 148,
+        "class": "heronarts.lx.LXChannel",
+        "modulationColor": -39680,
+        "internal": {
+          "controlsExpanded": true
+        },
+        "parameters": {
+          "label": "DIAGNOSTIC",
+          "arm": false,
+          "selected": true,
+          "enabled": false,
+          "cue": true,
+          "fader": 1.0,
+          "crossfadeGroup": 0,
+          "blendMode": 0,
+          "midiMonitor": false,
+          "midiChannel": 16,
+          "autoCycleEnabled": false,
+          "autoCycleMode": 0,
+          "autoCycleTimeSecs": 60.0,
+          "transitionEnabled": false,
+          "transitionTimeSecs": 5.0,
+          "transitionBlendMode": 0
+        },
+        "children": {},
+        "effects": [
+          {
+            "id": 315,
+            "class": "org.yomigae.effect.TempleMaskEffect",
+            "modulationColor": -65463,
+            "internal": {
+              "expanded": true,
+              "modulationExpanded": false
+            },
+            "parameters": {
+              "label": "TempleMask",
+              "enabled": true,
+              "twelve": true,
+              "six": true,
+              "nine": true,
+              "three": true,
+              "tunnel": true,
+              "hall": true
+            },
+            "children": {
+              "modulation": {
+                "id": 316,
+                "class": "heronarts.lx.LXModulationEngine",
+                "modulationColor": -1792,
+                "internal": {},
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            }
+          }
+        ],
+        "clips": [],
+        "patternIndex": 2,
+        "patterns": [
+          {
+            "id": 160,
+            "class": "heronarts.lx.pattern.IteratorPattern",
+            "modulationColor": -7601921,
+            "internal": {
+              "expanded": true,
+              "modulationExpanded": false,
+              "autoCycleEligible": false
+            },
+            "parameters": {
+              "label": "Iterator",
+              "speed": 1.9899999778717756
+            },
+            "children": {
+              "modulation": {
+                "id": 161,
+                "class": "heronarts.lx.LXModulationEngine",
+                "modulationColor": -59648,
+                "internal": {},
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            }
+          },
+          {
+            "id": 311,
+            "class": "org.yomigae.WhiteTemp",
+            "modulationColor": -3801344,
+            "internal": {
+              "expanded": true,
+              "modulationExpanded": false,
+              "autoCycleEligible": true
+            },
+            "parameters": {
+              "label": "WhiteTemp",
+              "Kelvins": 1900.0,
+              "Intensity": 1.0
+            },
+            "children": {
+              "modulation": {
+                "id": 312,
+                "class": "heronarts.lx.LXModulationEngine",
+                "modulationColor": -16766465,
+                "internal": {},
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            }
+          },
+          {
+            "id": 313,
+            "class": "heronarts.p3lx.pattern.SolidPattern",
+            "modulationColor": -256,
+            "internal": {
+              "expanded": true,
+              "modulationExpanded": false,
+              "autoCycleEligible": true
+            },
+            "parameters": {
+              "label": "Solid",
+              "color/brightness": 100.0,
+              "color/saturation": 100.0,
+              "color/hue": 0.0
+            },
+            "children": {
+              "modulation": {
+                "id": 314,
+                "class": "heronarts.lx.LXModulationEngine",
+                "modulationColor": -16711850,
+                "internal": {},
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "id": 30,
+        "class": "heronarts.lx.LXChannel",
+        "modulationColor": -62464,
+        "internal": {
+          "controlsExpanded": true
+        },
+        "parameters": {
+          "label": "Base Wash",
+          "arm": false,
+          "selected": false,
+          "enabled": true,
+          "cue": false,
+          "fader": 1.0,
+          "crossfadeGroup": 0,
+          "blendMode": 0,
+          "midiMonitor": false,
+          "midiChannel": 16,
+          "autoCycleEnabled": false,
+          "autoCycleMode": 0,
+          "autoCycleTimeSecs": 60.0,
+          "transitionEnabled": false,
+          "transitionTimeSecs": 5.0,
+          "transitionBlendMode": 0
+        },
+        "children": {},
+        "effects": [],
+        "clips": [],
+        "patternIndex": 0,
+        "patterns": [
+          {
+            "id": 146,
+            "class": "org.yomigae.WhiteTemp",
+            "modulationColor": -64000,
+            "internal": {
+              "expanded": true,
+              "modulationExpanded": false,
+              "autoCycleEligible": true
+            },
+            "parameters": {
+              "label": "WhiteTemp",
+              "Kelvins": 1900.0,
+              "Intensity": 0.5
+            },
+            "children": {
+              "modulation": {
+                "id": 147,
+                "class": "heronarts.lx.LXModulationEngine",
+                "modulationColor": -16721921,
+                "internal": {},
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "id": 230,
+        "class": "heronarts.lx.LXGroup",
+        "modulationColor": -65519,
+        "internal": {},
+        "parameters": {
+          "label": "Animation",
+          "arm": false,
+          "selected": false,
+          "enabled": true,
+          "cue": false,
+          "fader": 1.0,
+          "crossfadeGroup": 0,
+          "blendMode": 5
+        },
+        "children": {},
+        "effects": [],
+        "clips": []
+      },
+      {
+        "id": 92,
+        "class": "heronarts.lx.LXChannel",
+        "modulationColor": -13500161,
+        "internal": {
+          "controlsExpanded": true
+        },
+        "parameters": {
+          "label": "Moon",
+          "arm": false,
+          "selected": false,
+          "enabled": true,
+          "cue": false,
+          "fader": 1.0,
+          "crossfadeGroup": 0,
+          "blendMode": 0,
+          "midiMonitor": false,
+          "midiChannel": 16,
+          "autoCycleEnabled": false,
+          "autoCycleMode": 0,
+          "autoCycleTimeSecs": 60.0,
+          "transitionEnabled": false,
+          "transitionTimeSecs": 5.0,
+          "transitionBlendMode": 0
+        },
+        "children": {},
+        "effects": [],
+        "clips": [],
+        "patternIndex": 0,
+        "patterns": [
+          {
+            "id": 163,
+            "class": "org.yomigae.patterns.MoonPattern",
+            "modulationColor": -5832960,
+            "internal": {
+              "expanded": true,
+              "modulationExpanded": false,
+              "autoCycleEligible": true
+            },
+            "parameters": {
+              "label": "Moon",
+              "axis": 0,
+              "pos": 0.5,
+              "width": 0.4
+            },
+            "children": {
+              "modulation": {
+                "id": 164,
+                "class": "heronarts.lx.LXModulationEngine",
+                "modulationColor": -16711857,
+                "internal": {},
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            }
+          }
+        ],
+        "group": 230
+      },
+      {
+        "id": 216,
+        "class": "heronarts.lx.LXChannel",
+        "modulationColor": -7864576,
+        "internal": {
+          "controlsExpanded": true
+        },
+        "parameters": {
+          "label": "Colorize",
+          "arm": false,
+          "selected": false,
+          "enabled": true,
+          "cue": false,
+          "fader": 1.0,
+          "crossfadeGroup": 0,
+          "blendMode": 1,
+          "midiMonitor": false,
+          "midiChannel": 16,
+          "autoCycleEnabled": false,
+          "autoCycleMode": 0,
+          "autoCycleTimeSecs": 60.0,
+          "transitionEnabled": false,
+          "transitionTimeSecs": 5.0,
+          "transitionBlendMode": 0
+        },
+        "children": {},
+        "effects": [],
+        "clips": [],
+        "patternIndex": 0,
+        "patterns": [
+          {
+            "id": 237,
+            "class": "org.yomigae.WhiteTemp",
+            "modulationColor": -16122112,
+            "internal": {
+              "expanded": true,
+              "modulationExpanded": false,
+              "autoCycleEligible": true
+            },
+            "parameters": {
+              "label": "WhiteTemp",
+              "Kelvins": 1900.0,
+              "Intensity": 1.0
+            },
+            "children": {
+              "modulation": {
+                "id": 238,
+                "class": "heronarts.lx.LXModulationEngine",
+                "modulationColor": -12844801,
+                "internal": {},
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            }
+          }
+        ],
+        "group": 230
+      }
+    ]
+  },
+  "externals": {
+    "ui": {
+      "audioExpanded": false,
+      "paletteExpanded": false,
+      "cameraExpanded": true,
+      "clipViewVisible": false,
+      "modulatorExpanded": {},
+      "preview": {
+        "mode": 0,
+        "animation": true,
+        "animationTime": 1000.0,
+        "projection": 0,
+        "perspective": 60.0,
+        "depth": 1.0,
+        "phiLock": true,
+        "centerPoint": false,
+        "camera": {
+          "active": true,
+          "radius": 100.3562158334115,
+          "theta": -0.011512354644351207,
+          "phi": 1.4137166738510132,
+          "x": 2.6067725567845628,
+          "y": 15.261767351999879,
+          "z": 0.3426573275064584
+        },
+        "cue": [
+          {
+            "active": true,
+            "radius": 131.2284926927776,
+            "theta": -0.007674891301460539,
+            "phi": 0.09324641555879581,
+            "x": 8.425665123853832,
+            "y": 21.0922247543931,
+            "z": 0.8989533502608538
+          },
+          {
+            "active": true,
+            "radius": 100.3562158334115,
+            "theta": -0.011512354644351207,
+            "phi": 1.4137166738510132,
+            "x": 2.6067725567845628,
+            "y": 15.261767351999879,
+            "z": 0.3426573275064584
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          }
+        ],
+        "focus": 1,
+        "pointCloud": {
+          "pointSize": 3.0
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/org/yomigae/Yomigae.java
+++ b/src/main/java/org/yomigae/Yomigae.java
@@ -3,6 +3,7 @@ package org.yomigae;
 import com.google.common.reflect.ClassPath;
 import heronarts.lx.LXEffect;
 import heronarts.lx.LXPattern;
+import heronarts.lx.blend.LightestBlend;
 import heronarts.lx.studio.LXStudio;
 
 import java.io.IOException;
@@ -177,6 +178,7 @@ public class Yomigae extends PApplet {
 
     // Register any patterns and effects LX doesn't recognize
     registerAll(lx);
+    lx.registerBlend(LightestBlend.class);
   }
 
   public void onUIReady(LXStudio lx, LXStudio.UI ui) {

--- a/src/main/java/org/yomigae/model/TempleModel.java
+++ b/src/main/java/org/yomigae/model/TempleModel.java
@@ -124,7 +124,8 @@ public class TempleModel extends LXModel {
 	}
 
 	private static void buildHalfTemple(List<LXModel> submodels, int direction, LXTransform t) {
-		t.translate((13 + 11 / 12.f) / 2.f, 0, 0);
+		// translate from temple center (0, 0, 0) to edge of first T6
+		t.translate(direction * (13 + 11 / 12.f) / 2.f, 0, 0);
 
 		String directionTag = direction < 0 ? SIX_OCLOCK_KEY : TWELVE_OCLOCK_KEY;
 		List<String> tunnelKeys = ImmutableList.of(TUNNEL_KEY, directionTag);
@@ -136,7 +137,7 @@ public class TempleModel extends LXModel {
 
 		for (int i = 0; i < 5; ++i) {
 			submodels.add(createTorii(direction, ToriiModel.ToriiType.T1, t, tunnelKeys));
-			t.translate(i < 5 - 1 ? 1 + 11 / 12.f : 0, 0, 0);
+			t.translate(i < 5 - 1 ? direction * (1 + 11 / 12.f) : 0, 0, 0);
 		}
 	}
 

--- a/src/main/java/org/yomigae/model/ToriiModel.java
+++ b/src/main/java/org/yomigae/model/ToriiModel.java
@@ -108,13 +108,14 @@ public class ToriiModel extends LXModel {
 		List<LXModel> submodels = new ArrayList<>();
 
 		t.push();
+		// translate to center of torii
 		t.translate(columnDepth / 2 * direction, 0, 0);
 
 		float zOffset = 0;
 		switch (toriiType.toIndex()) {
 			case 0: // T1
 				// move 2 meters out from column base
-				zOffset = 6 + 6.75f / 12.f - openingWidth / 2 - columnWidth;
+				zOffset = (6 + 6.75f / 12.f) + openingWidth / 2 + columnWidth;
 
 				t.push();
 				t.translate(0, 0, zOffset);
@@ -128,7 +129,7 @@ public class ToriiModel extends LXModel {
 				break;
 			case 1: // T2
 				// move half a foot from eave end
-				zOffset = 6 / 12.f - beamLength / 2;
+				zOffset = (beamLength / 2) - (6 / 12.f);
 
 				t.push();
 				t.translate(0, columnHeight, zOffset);
@@ -142,7 +143,7 @@ public class ToriiModel extends LXModel {
 				break;
 			default: // T3-T6
 				// move half a foot from eave end
-				zOffset = 6 / 12.f - beamLength / 2;
+				zOffset = (beamLength / 2) - (6 / 12.f);
 
 				t.push();
 				t.translate(1.5f, columnHeight, zOffset);


### PR DESCRIPTION
Updated a few x-translations to include the build direction corresponding to the temple half being built.

This fixes the differences in spacing between the T1 par lights on either side of the temple.

However, position `0.5` still doesn't seem to fall directly on the center of the model.

Also updated z-translation distances.